### PR TITLE
fix: remover límite de 50 caracteres en campo serie

### DIFF
--- a/backend/src/middlewares/guias.validators.ts
+++ b/backend/src/middlewares/guias.validators.ts
@@ -69,9 +69,7 @@ export const validateGenerarGuia = [
   body('detalle.*.serie')
     .optional()
     .isString()
-    .withMessage('La serie debe ser texto')
-    .isLength({ max: 50 })
-    .withMessage('La serie no puede exceder 50 caracteres'),
+    .withMessage('La serie debe ser texto'),
 
   // Middleware para manejar errores de validación
   (req: Request, res: Response, next: NextFunction) => {

--- a/backend/src/utils/constants.ts
+++ b/backend/src/utils/constants.ts
@@ -113,6 +113,6 @@ export const ANCHOS_COLUMNAS = {
     gre_id: 15,
     cantidad: 15,
     sku: 20,
-    serie: 25,
+    serie: 200,
   },
 };

--- a/frontend/src/lib/validations.ts
+++ b/frontend/src/lib/validations.ts
@@ -189,7 +189,6 @@ export const guiaSchema = z.object({
         
         serie: z
           .string()
-          .max(50, 'Máximo 50 caracteres')
           .optional()
           .or(z.literal('')),
       })


### PR DESCRIPTION
- Frontend: removido .max(50) de validación Zod
- Backend: removido .isLength({ max: 50 }) de express-validator
- Backend: aumentado ancho de columna Serie en Excel de 25 a 200