### PR TITLE
fix: corregir detección de cambios en formularios de edición

### DIFF
--- a/frontend/src/features/categorias/components/tabs/SubcategoriaFormModal.tsx
+++ b/frontend/src/features/categorias/components/tabs/SubcategoriaFormModal.tsx
@@ -59,8 +59,12 @@ export const SubcategoriaFormModal: React.FC<SubcategoriaFormModalProps> = ({
     if (subcategoria) {
       form.reset({
         nombre: subcategoria.nombre,
-        activo: subcategoria.activo,
-      });
+        activo: Boolean(subcategoria.activo),
+      },
+      {
+        keepDefaultValues: false, 
+      }
+    );
     } else {
       form.reset({
         nombre: '',

--- a/frontend/src/features/marcas/components/MarcaFormModal.tsx
+++ b/frontend/src/features/marcas/components/MarcaFormModal.tsx
@@ -51,14 +51,20 @@ export const MarcaFormModal: React.FC<MarcaFormModalProps> = ({
       nombre: '',
       activo: true,
     },
+    mode: 'onChange',
   });
 
   useEffect(() => {
     if (marca) {
-      form.reset({
-        nombre: marca.nombre,
-        activo: marca.activo,
-      });
+      form.reset(
+        {
+          nombre: marca.nombre,
+          activo: Boolean(marca.activo),
+        },
+        {
+          keepDefaultValues: false,
+        }
+      );
     } else {
       form.reset({
         nombre: '',
@@ -68,7 +74,7 @@ export const MarcaFormModal: React.FC<MarcaFormModalProps> = ({
   }, [marca, form]);
 
   const onSubmit = (data: MarcaFormValues) => {
-    if (isEditing) {
+    if (isEditing && marca) {
       updateMutation.mutate(
         { id: marca.id, data },
         {
@@ -87,6 +93,8 @@ export const MarcaFormModal: React.FC<MarcaFormModalProps> = ({
       });
     }
   };
+
+  const isLoading = crearMutation.isPending || updateMutation.isPending;
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -134,19 +142,12 @@ export const MarcaFormModal: React.FC<MarcaFormModalProps> = ({
                 type="button"
                 variant="outline"
                 onClick={() => onOpenChange(false)}
-                disabled={crearMutation.isPending || updateMutation.isPending}
+                disabled={isLoading}
               >
                 Cancelar
               </Button>
-              <Button
-                type="submit"
-                disabled={crearMutation.isPending || updateMutation.isPending}
-              >
-                {crearMutation.isPending || updateMutation.isPending
-                  ? 'Guardando...'
-                  : isEditing
-                  ? 'Actualizar'
-                  : 'Crear'}
+              <Button type="submit" disabled={isLoading}>
+                {isLoading ? 'Guardando...' : isEditing ? 'Actualizar' : 'Crear'}
               </Button>
             </div>
           </form>

--- a/frontend/src/features/modelos/components/ModeloFormModal.tsx
+++ b/frontend/src/features/modelos/components/ModeloFormModal.tsx
@@ -86,8 +86,12 @@ export const ModeloFormModal: React.FC<ModeloFormModalProps> = ({
         especificaciones_tecnicas: modelo.especificaciones_tecnicas
           ? JSON.stringify(modelo.especificaciones_tecnicas, null, 2)
           : '',
-        activo: modelo.activo,
-      });
+        activo: Boolean(modelo.activo),
+      },
+      {
+        keepDefaultValues: false,  
+      }
+    );
     } else {
       form.reset({
         subcategoria_id: 0,


### PR DESCRIPTION
- Agregar Boolean() en reset de activo para conversión correcta de tipos (BD devuelve 0/1)
- Agregar keepDefaultValues: false en form.reset() para detectar cambios en modo edición
- Aplicado en MarcaFormModal, SubcategoriaFormModal y ModeloFormModal
- Ahora se puede actualizar sin necesidad de cambiar el estado activo/inactivo

Problema resuelto: React Hook Form no detectaba cambios cuando solo se modificaba un campo sin tocar el switch, debido a que la BD devuelve tinyint (0/1) y el formulario esperaba boolean (true/false)